### PR TITLE
usbkeyboard: fix double printing of input

### DIFF
--- a/devices/usbkeyboard/basic_stdin/source/basic_stdin.c
+++ b/devices/usbkeyboard/basic_stdin/source/basic_stdin.c
@@ -12,12 +12,13 @@ static GXRModeObj *rmode = NULL;
 
 bool quitapp = false;
 
-void keyPress_cb(char sym) {
-	if (sym == 0x1b)
-		quitapp = true;
+void keyPress_cb(char sym)
+{
+	putchar(sym); // Display the pressed character
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char **argv)
+{
 	// Initialise the video system
 	VIDEO_Init();
 
@@ -60,7 +61,8 @@ int main(int argc, char **argv) {
 	if (KEYBOARD_Init(keyPress_cb) == 0)
 		printf("keyboard initialised\n");
 
-	do {
+	do
+	{
 		// Call WPAD_ScanPads each loop, this reads the latest controller states
 		WPAD_ScanPads();
 
@@ -72,15 +74,23 @@ int main(int argc, char **argv) {
 		// Check for keyboard input
 		int key;
 
-		if ((key = getchar()) != EOF) {
+		if ((key = getchar()) != EOF)
+		{
+			// Check for escape key to exit
+			if (key == 0x1b)
+			{
+				quitapp = true;
+			}
+			else
+			{
+				// Print readable characters (ASCII > 31)
+				if (key > 31)
+					; // putchar is now in the callback
 
-			// Print readable characters (ASCII > 31)
-			if (key > 31)
-				putchar(key);
-
-			// Convert Enter key (ASCII 13) to a newline
-			if (key == 13)
-				putchar('\n');
+				// Convert Enter key (ASCII 13) to a newline
+				if (key == 13)
+					putchar('\n');
+			}
 		}
 
 		// We return to the launcher application via exit

--- a/devices/usbkeyboard/basic_stdin/source/basic_stdin.c
+++ b/devices/usbkeyboard/basic_stdin/source/basic_stdin.c
@@ -1,6 +1,7 @@
 #include <gccore.h>
 #include <wiiuse/wpad.h>
 #include <wiikeyboard/keyboard.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -8,6 +9,7 @@
 
 static void *xfb = NULL;
 static GXRModeObj *rmode = NULL;
+
 bool quitapp=false;
 
 void keyPress_cb(char sym) {
@@ -15,32 +17,70 @@ void keyPress_cb(char sym) {
 }
 
 int main(int argc, char **argv) {
+    // Initialise the video system
     VIDEO_Init();
+
+    // This function initialises the attached controllers
     WPAD_Init();
+
+    // Obtain the preferred video mode from the system
+	// This will correspond to the settings in the Wii menu
     rmode = VIDEO_GetPreferredMode(NULL);
+
+    // Allocate memory for the display in the uncached region
     xfb = MEM_K0_TO_K1(SYS_AllocateFramebuffer(rmode));
+
+    // Initialise the console, required for printf
     console_init(xfb,20,20,rmode->fbWidth,rmode->xfbHeight,rmode->fbWidth*VI_DISPLAY_PIX_SZ);
+
+    // Set up the video registers with the chosen mode
     VIDEO_Configure(rmode);
+
+    // Tell the video hardware where our display memory is
     VIDEO_SetNextFramebuffer(xfb);
+
+    // Make the display visible
     VIDEO_SetBlack(false);
+
+    // Flush the video register changes to the hardware
     VIDEO_Flush();
+
+    // Wait for Video setup to complete
     VIDEO_WaitVSync();
     if(rmode->viTVMode&VI_NON_INTERLACE) VIDEO_WaitVSync();
 
+	// The console understands VT terminal escape codes
+	// This positions the cursor on row 2, column 0
+	// we can use variables for this with format codes too
+	// e.g. printf ("\x1b[%d;%dH", row, column );
     printf("\x1b[2;0HHello World!\n");
     if (KEYBOARD_Init(keyPress_cb) == 0) printf("keyboard initialised\n");
 
     do {
+        // Call WPAD_ScanPads each loop, this reads the latest controller states
         WPAD_ScanPads();
+
+        // WPAD_ButtonsDown tells us which buttons were pressed in this loop
+		// this is a "one shot" state which will not fire again until the button has been released
         u32 pressed = WPAD_ButtonsDown(0);
-        
+
+        // Check for keyboard input
         int key;
+
+        
         if((key = getchar()) != EOF) {
+
+            // Print readable characters (ASCII > 31)
             if(key > 31) putchar(key);
+
+            // Convert Enter key (ASCII 13) to a newline
             if(key == 13) putchar('\n');
         }
         
+        // We return to the launcher application via exit
         if (pressed & WPAD_BUTTON_HOME) quitapp=true;
+
+		// Wait for the next frame
         VIDEO_WaitVSync();
     } while(!quitapp);
 

--- a/devices/usbkeyboard/basic_stdin/source/basic_stdin.c
+++ b/devices/usbkeyboard/basic_stdin/source/basic_stdin.c
@@ -14,7 +14,9 @@ bool quitapp = false;
 
 void keyPress_cb(char sym)
 {
-	putchar(sym); // Display the pressed character
+	// Check for escape key to exit
+	if (key == 0x1b)
+		quitapp = true;
 }
 
 int main(int argc, char **argv)
@@ -76,21 +78,13 @@ int main(int argc, char **argv)
 
 		if ((key = getchar()) != EOF)
 		{
-			// Check for escape key to exit
-			if (key == 0x1b)
-			{
-				quitapp = true;
-			}
-			else
-			{
-				// Print readable characters (ASCII > 31)
-				if (key > 31)
-					; // putchar is now in the callback
-
-				// Convert Enter key (ASCII 13) to a newline
-				if (key == 13)
-					putchar('\n');
-			}
+			// Display the pressed character
+			// Print readable characters (ASCII > 31)
+			if (key > 31)
+				putchar(sym);
+			// Convert Enter key (ASCII 13) to a newline
+			else if(key == 13)
+				putchar('\n');
 		}
 
 		// We return to the launcher application via exit

--- a/devices/usbkeyboard/basic_stdin/source/basic_stdin.c
+++ b/devices/usbkeyboard/basic_stdin/source/basic_stdin.c
@@ -1,6 +1,6 @@
 #include <gccore.h>
-#include <wiiuse/wpad.h>
 #include <wiikeyboard/keyboard.h>
+#include <wiiuse/wpad.h>
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -10,79 +10,86 @@
 static void *xfb = NULL;
 static GXRModeObj *rmode = NULL;
 
-bool quitapp=false;
+bool quitapp = false;
 
 void keyPress_cb(char sym) {
-    if (sym == 0x1b) quitapp = true;
+	if (sym == 0x1b)
+		quitapp = true;
 }
 
 int main(int argc, char **argv) {
-    // Initialise the video system
-    VIDEO_Init();
+	// Initialise the video system
+	VIDEO_Init();
 
-    // This function initialises the attached controllers
-    WPAD_Init();
+	// This function initialises the attached controllers
+	WPAD_Init();
 
-    // Obtain the preferred video mode from the system
+	// Obtain the preferred video mode from the system
 	// This will correspond to the settings in the Wii menu
-    rmode = VIDEO_GetPreferredMode(NULL);
+	rmode = VIDEO_GetPreferredMode(NULL);
 
-    // Allocate memory for the display in the uncached region
-    xfb = MEM_K0_TO_K1(SYS_AllocateFramebuffer(rmode));
+	// Allocate memory for the display in the uncached region
+	xfb = MEM_K0_TO_K1(SYS_AllocateFramebuffer(rmode));
 
-    // Initialise the console, required for printf
-    console_init(xfb,20,20,rmode->fbWidth,rmode->xfbHeight,rmode->fbWidth*VI_DISPLAY_PIX_SZ);
+	// Initialise the console, required for printf
+	console_init(xfb, 20, 20, rmode->fbWidth, rmode->xfbHeight,
+				 rmode->fbWidth * VI_DISPLAY_PIX_SZ);
 
-    // Set up the video registers with the chosen mode
-    VIDEO_Configure(rmode);
+	// Set up the video registers with the chosen mode
+	VIDEO_Configure(rmode);
 
-    // Tell the video hardware where our display memory is
-    VIDEO_SetNextFramebuffer(xfb);
+	// Tell the video hardware where our display memory is
+	VIDEO_SetNextFramebuffer(xfb);
 
-    // Make the display visible
-    VIDEO_SetBlack(false);
+	// Make the display visible
+	VIDEO_SetBlack(false);
 
-    // Flush the video register changes to the hardware
-    VIDEO_Flush();
+	// Flush the video register changes to the hardware
+	VIDEO_Flush();
 
-    // Wait for Video setup to complete
-    VIDEO_WaitVSync();
-    if(rmode->viTVMode&VI_NON_INTERLACE) VIDEO_WaitVSync();
+	// Wait for Video setup to complete
+	VIDEO_WaitVSync();
+	if (rmode->viTVMode & VI_NON_INTERLACE)
+		VIDEO_WaitVSync();
 
 	// The console understands VT terminal escape codes
 	// This positions the cursor on row 2, column 0
 	// we can use variables for this with format codes too
 	// e.g. printf ("\x1b[%d;%dH", row, column );
-    printf("\x1b[2;0HHello World!\n");
-    if (KEYBOARD_Init(keyPress_cb) == 0) printf("keyboard initialised\n");
+	printf("\x1b[2;0HHello World!\n");
+	if (KEYBOARD_Init(keyPress_cb) == 0)
+		printf("keyboard initialised\n");
 
-    do {
-        // Call WPAD_ScanPads each loop, this reads the latest controller states
-        WPAD_ScanPads();
+	do {
+		// Call WPAD_ScanPads each loop, this reads the latest controller states
+		WPAD_ScanPads();
 
-        // WPAD_ButtonsDown tells us which buttons were pressed in this loop
-		// this is a "one shot" state which will not fire again until the button has been released
-        u32 pressed = WPAD_ButtonsDown(0);
+		// WPAD_ButtonsDown tells us which buttons were pressed in this loop
+		// this is a "one shot" state which will not fire again until the button
+		// has been released
+		u32 pressed = WPAD_ButtonsDown(0);
 
-        // Check for keyboard input
-        int key;
+		// Check for keyboard input
+		int key;
 
-        
-        if((key = getchar()) != EOF) {
+		if ((key = getchar()) != EOF) {
 
-            // Print readable characters (ASCII > 31)
-            if(key > 31) putchar(key);
+			// Print readable characters (ASCII > 31)
+			if (key > 31)
+				putchar(key);
 
-            // Convert Enter key (ASCII 13) to a newline
-            if(key == 13) putchar('\n');
-        }
-        
-        // We return to the launcher application via exit
-        if (pressed & WPAD_BUTTON_HOME) quitapp=true;
+			// Convert Enter key (ASCII 13) to a newline
+			if (key == 13)
+				putchar('\n');
+		}
+
+		// We return to the launcher application via exit
+		if (pressed & WPAD_BUTTON_HOME)
+			quitapp = true;
 
 		// Wait for the next frame
-        VIDEO_WaitVSync();
-    } while(!quitapp);
+		VIDEO_WaitVSync();
+	} while (!quitapp);
 
-    return 0;
+	return 0;
 }

--- a/devices/usbkeyboard/basic_stdin/source/basic_stdin.c
+++ b/devices/usbkeyboard/basic_stdin/source/basic_stdin.c
@@ -1,85 +1,48 @@
 #include <gccore.h>
 #include <wiiuse/wpad.h>
 #include <wiikeyboard/keyboard.h>
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 
-
 static void *xfb = NULL;
 static GXRModeObj *rmode = NULL;
-
 bool quitapp=false;
 
-void keyPress_cb( char sym) {
-
-	if (sym > 31 ) putchar(sym);
-	if (sym == 13) putchar('\n');
-
-	if ( sym == 0x1b) quitapp = true;
+void keyPress_cb(char sym) {
+    if (sym == 0x1b) quitapp = true;
 }
 
-
 int main(int argc, char **argv) {
-	// Initialise the video system
-	VIDEO_Init();
+    VIDEO_Init();
+    WPAD_Init();
+    rmode = VIDEO_GetPreferredMode(NULL);
+    xfb = MEM_K0_TO_K1(SYS_AllocateFramebuffer(rmode));
+    console_init(xfb,20,20,rmode->fbWidth,rmode->xfbHeight,rmode->fbWidth*VI_DISPLAY_PIX_SZ);
+    VIDEO_Configure(rmode);
+    VIDEO_SetNextFramebuffer(xfb);
+    VIDEO_SetBlack(false);
+    VIDEO_Flush();
+    VIDEO_WaitVSync();
+    if(rmode->viTVMode&VI_NON_INTERLACE) VIDEO_WaitVSync();
 
-	// This function initialises the attached controllers
-	WPAD_Init();
+    printf("\x1b[2;0HHello World!\n");
+    if (KEYBOARD_Init(keyPress_cb) == 0) printf("keyboard initialised\n");
 
-	// Obtain the preferred video mode from the system
-	// This will correspond to the settings in the Wii menu
-	rmode = VIDEO_GetPreferredMode(NULL);
+    do {
+        WPAD_ScanPads();
+        u32 pressed = WPAD_ButtonsDown(0);
+        
+        int key;
+        if((key = getchar()) != EOF) {
+            if(key > 31) putchar(key);
+            if(key == 13) putchar('\n');
+        }
+        
+        if (pressed & WPAD_BUTTON_HOME) quitapp=true;
+        VIDEO_WaitVSync();
+    } while(!quitapp);
 
-	// Allocate memory for the display in the uncached region
-	xfb = MEM_K0_TO_K1(SYS_AllocateFramebuffer(rmode));
-
-	// Initialise the console, required for printf
-	console_init(xfb,20,20,rmode->fbWidth,rmode->xfbHeight,rmode->fbWidth*VI_DISPLAY_PIX_SZ);
-
-	// Set up the video registers with the chosen mode
-	VIDEO_Configure(rmode);
-
-	// Tell the video hardware where our display memory is
-	VIDEO_SetNextFramebuffer(xfb);
-
-	// Make the display visible
-	VIDEO_SetBlack(false);
-
-	// Flush the video register changes to the hardware
-	VIDEO_Flush();
-
-	// Wait for Video setup to complete
-	VIDEO_WaitVSync();
-	if(rmode->viTVMode&VI_NON_INTERLACE) VIDEO_WaitVSync();
-
-
-	// The console understands VT terminal escape codes
-	// This positions the cursor on row 2, column 0
-	// we can use variables for this with format codes too
-	// e.g. printf ("\x1b[%d;%dH", row, column );
-	printf("\x1b[2;0HHello World!\n");
-
-	if (KEYBOARD_Init(keyPress_cb) == 0) printf("keyboard initialised\n");
-
-	do {
-		// Call WPAD_ScanPads each loop, this reads the latest controller states
-		WPAD_ScanPads();
-
-		// WPAD_ButtonsDown tells us which buttons were pressed in this loop
-		// this is a "one shot" state which will not fire again until the button has been released
-		u32 pressed = WPAD_ButtonsDown(0);
-
-		int key = getchar();
-		putchar(key);
-		// We return to the launcher application via exit
-		if ( pressed & WPAD_BUTTON_HOME ) quitapp=true;
-
-		// Wait for the next frame
-		VIDEO_WaitVSync();
-	} while(!quitapp);
-
-	return 0;
+    return 0;
 }


### PR DESCRIPTION
See issue: https://github.com/devkitPro/wii-examples/issues/19

The previous implementation caused duplicate character output due to both the keyPress_cb function and the main loop handling keyboard input. The keyPress_cb function directly printed characters, while the main loop read and reprinted them using getchar().

Now, the main loop uses non-blocking getchar() for centralized character handling, ensuring controlled output of printable and newline characters. The keyPress_cb function handles the escape key to exit the application.

Key changes:

-     Removed putchar() calls from keyPress_cb in usbkeyboard.c.
-     Updated the main loop in usbkeyboard.c to manage character printing centrally using non-blocking getchar().