### PR TITLE
fix usbkeyboard build

### DIFF
--- a/devices/usbkeyboard/basic_stdin/source/basic_stdin.c
+++ b/devices/usbkeyboard/basic_stdin/source/basic_stdin.c
@@ -15,7 +15,7 @@ bool quitapp = false;
 void keyPress_cb(char sym)
 {
 	// Check for escape key to exit
-	if (key == 0x1b)
+	if (sym == 0x1b)
 		quitapp = true;
 }
 
@@ -81,7 +81,7 @@ int main(int argc, char **argv)
 			// Display the pressed character
 			// Print readable characters (ASCII > 31)
 			if (key > 31)
-				putchar(sym);
+				putchar(key);
 			// Convert Enter key (ASCII 13) to a newline
 			else if(key == 13)
 				putchar('\n');


### PR DESCRIPTION
https://github.com/devkitPro/wii-examples/pull/20/commits/8667084689a1e1ac09887e0b521e80406871d98c
that cleanup commit broke it

just wondering, is this known to not work on dolphin? I enabled "Connect USB keyboard" and nothing happens when typing