### PR TITLE
threading: initialize variable to 0

### DIFF
--- a/threading/source/main.c
+++ b/threading/source/main.c
@@ -176,6 +176,7 @@ int main(int argc, char** argv) {
         printf("Setting up demo data[%d]...\n", idx);
         demo_data[idx].id = idx+1;          // Set ID
         demo_data[idx].tg = rand() % 10;    // Random Target Value.
+        demo_data[idx].var = 0;
     }
 
     // Area to store the return values of the threads.


### PR DESCRIPTION
malloc() does not initialize the memory to 0 like calloc does, so the `var` member needs to be initialized like the other ones.

This is not a problem in Dolphin, but it shows up on the console.
