### PR TITLE
Stop compiler from assuming UTF-8 encoding in strings

### DIFF
--- a/templates/cmake/application/CMakeLists.txt
+++ b/templates/cmake/application/CMakeLists.txt
@@ -8,7 +8,7 @@ target_sources(${PROJECT_NAME} PRIVATE
 	source/main.c
 )
 
-target_compile_options(${PROJECT_NAME} PRIVATE -Wall)
+target_compile_options(${PROJECT_NAME} PRIVATE -fexec-charset=CP437 -Wall)
 
 target_include_directories(${PROJECT_NAME} PRIVATE
   include

--- a/templates/makefile/application/Makefile
+++ b/templates/makefile/application/Makefile
@@ -25,7 +25,7 @@ INCLUDES	:=
 # options for code generation
 #---------------------------------------------------------------------------------
 
-CFLAGS	= -g -O2 -Wall $(MACHDEP) $(INCLUDE)
+CFLAGS	= -g -O2 -fexec-charset=CP437 -Wall $(MACHDEP) $(INCLUDE)
 CXXFLAGS	=	$(CFLAGS)
 
 LDFLAGS	=	-g $(MACHDEP) -Wl,-Map,$(notdir $@).map


### PR DESCRIPTION
A while back I had an issue with getting strings with non-ASCII characters in my code to work (I wanted this for better visibility in my code) and realized it was because the compiler was assuming I wanted UTF-8 encoding in my program. Normally this acts perfectly fine, but in my case (where I was using special non-ASCII characters) this lead to mojibake appearing instead of box drawing characters. I felt that adding this flag to the compiler would make it easier to fully use the console. I do see that this might cause similar problems on any library that wants UTF-8 in their strings though.