### PR TITLE
Remove Undefined Behavior in ISFS Example

### DIFF
--- a/filesystem/directory/isfs/source/main.c
+++ b/filesystem/directory/isfs/source/main.c
@@ -357,6 +357,8 @@ int main(int argc, char** argv) {
     DIR_ENTRY parent;
     parent.abspath = malloc(ISFS_MAXPATH);
     parent.flags = FLAG_DIR;
+    parent.children = NULL;
+    parent.size = 0;
     sprintf(parent.abspath, "/");
     ReadDirectory(&parent);
 

--- a/filesystem/directory/isfs/source/main.c
+++ b/filesystem/directory/isfs/source/main.c
@@ -354,11 +354,9 @@ int main(int argc, char** argv) {
     Init();
 
     // Directory Entry
-    DIR_ENTRY parent;
+    DIR_ENTRY parent = {0};
     parent.abspath = malloc(ISFS_MAXPATH);
     parent.flags = FLAG_DIR;
-    parent.children = NULL;
-    parent.size = 0;
     sprintf(parent.abspath, "/");
     ReadDirectory(&parent);
 


### PR DESCRIPTION
Undefined behavior was causing crashes in isfs.c, because specific values on the initial directory read from were expected to by 0 but had the chance to not be
Specifically, with the initial directory that gets read, the children pointer may not have been `NULL`, leading to `AddChildEntry` assuming there was already allocated data, and `size` could've been nonzero, leading it to assume the total number of children had already been requested (although likely with no effect on the example program itself)