### PR TITLE
Update all old examples to include framebuffer clear

### DIFF
--- a/audio/modplay/source/template.c
+++ b/audio/modplay/source/template.c
@@ -47,6 +47,9 @@ int main(int argc, char **argv) {
 	// Flush the video register changes to the hardware
 	VIDEO_Flush();
 
+    // Clear framebuffer
+    VIDEO_ClearFrameBuffer(rmode,xfb,COLOR_BLACK);
+
 	// Wait for Video setup to complete
 	VIDEO_WaitVSync();
 	if(rmode->viTVMode&VI_NON_INTERLACE) VIDEO_WaitVSync();

--- a/audio/mp3player/source/template.c
+++ b/audio/mp3player/source/template.c
@@ -47,6 +47,9 @@ int main(int argc, char **argv) {
 	// Flush the video register changes to the hardware
 	VIDEO_Flush();
 
+    // Clear framebuffer
+    VIDEO_ClearFrameBuffer(rmode,xfb,COLOR_BLACK);
+
 	// Wait for Video setup to complete
 	VIDEO_WaitVSync();
 	if(rmode->viTVMode&VI_NON_INTERLACE) VIDEO_WaitVSync();

--- a/audio/oggplayer/source/template.c
+++ b/audio/oggplayer/source/template.c
@@ -52,6 +52,9 @@ int main(int argc, char **argv) {
 	// Flush the video register changes to the hardware
 	VIDEO_Flush();
 
+    // Clear framebuffer
+    VIDEO_ClearFrameBuffer(rmode,xfb,COLOR_BLACK);
+
 	// Wait for Video setup to complete
 	VIDEO_WaitVSync();
 	if(rmode->viTVMode&VI_NON_INTERLACE) VIDEO_WaitVSync();

--- a/crypto/source/crypto.c
+++ b/crypto/source/crypto.c
@@ -80,6 +80,9 @@ int main(int argc, char **argv) {
 	// Flush the video register changes to the hardware
 	VIDEO_Flush();
 
+    // Clear framebuffer
+    VIDEO_ClearFrameBuffer(rmode,xfb,COLOR_BLACK);
+
 	// Wait for Video setup to complete
 	VIDEO_WaitVSync();
 	if(rmode->viTVMode&VI_NON_INTERLACE) VIDEO_WaitVSync();

--- a/devices/network/sockettest/source/sockettest.c
+++ b/devices/network/sockettest/source/sockettest.c
@@ -161,6 +161,7 @@ void *initialise() {
 	VIDEO_SetNextFramebuffer(framebuffer);
 	VIDEO_SetBlack(false);
 	VIDEO_Flush();
+    VIDEO_ClearFrameBuffer(rmode,xfb,COLOR_BLACK);
 	VIDEO_WaitVSync();
 	if(rmode->viTVMode&VI_NON_INTERLACE) VIDEO_WaitVSync();
 

--- a/devices/network/udptest/source/udptest.c
+++ b/devices/network/udptest/source/udptest.c
@@ -27,6 +27,7 @@ static void initialise() {
     VIDEO_SetNextFramebuffer(framebuffer);
     VIDEO_SetBlack(false);
     VIDEO_Flush();
+    VIDEO_ClearFrameBuffer(rmode,xfb,COLOR_BLACK);
     VIDEO_WaitVSync();
     if (rmode->viTVMode & VI_NON_INTERLACE) VIDEO_WaitVSync();
 }

--- a/devices/usbgecko/gdbstub/source/gdbstub.c
+++ b/devices/usbgecko/gdbstub/source/gdbstub.c
@@ -24,6 +24,7 @@ int main() {
 	VIDEO_SetNextFramebuffer(xfb);
 	VIDEO_SetBlack(false);
 	VIDEO_Flush();
+    VIDEO_ClearFrameBuffer(rmode,xfb,COLOR_BLACK);
 	VIDEO_WaitVSync();
 	if(rmode->viTVMode&VI_NON_INTERLACE) VIDEO_WaitVSync();
 

--- a/devices/usbkeyboard/basic_stdin/source/basic_stdin.c
+++ b/devices/usbkeyboard/basic_stdin/source/basic_stdin.c
@@ -50,6 +50,9 @@ int main(int argc, char **argv)
 	// Flush the video register changes to the hardware
 	VIDEO_Flush();
 
+    // Clear framebuffer
+    VIDEO_ClearFrameBuffer(rmode,xfb,COLOR_BLACK);
+
 	// Wait for Video setup to complete
 	VIDEO_WaitVSync();
 	if (rmode->viTVMode & VI_NON_INTERLACE)

--- a/filesystem/directory/isfs/source/main.c
+++ b/filesystem/directory/isfs/source/main.c
@@ -326,6 +326,7 @@ static void Init() {
 	VIDEO_SetNextFramebuffer(xfb);
 	VIDEO_SetBlack(false);
 	VIDEO_Flush();
+    VIDEO_ClearFrameBuffer(rmode,xfb,COLOR_BLACK);
 	VIDEO_WaitVSync();
 	if(rmode->viTVMode&VI_NON_INTERLACE) VIDEO_WaitVSync();
 

--- a/filesystem/directory/sd/source/directory.c
+++ b/filesystem/directory/sd/source/directory.c
@@ -46,6 +46,9 @@ int main(int argc, char **argv) {
 	// Flush the video register changes to the hardware
 	VIDEO_Flush();
 
+    // Clear framebuffer
+    VIDEO_ClearFrameBuffer(rmode,xfb,COLOR_BLACK);
+
 	// Wait for Video setup to complete
 	VIDEO_WaitVSync();
 	if(rmode->viTVMode&VI_NON_INTERLACE) VIDEO_WaitVSync();

--- a/templates/cmake/application/source/main.c
+++ b/templates/cmake/application/source/main.c
@@ -38,6 +38,9 @@ int main(int argc, char **argv) {
 	// Flush the video register changes to the hardware
 	VIDEO_Flush();
 
+    // Clear framebuffer
+    VIDEO_ClearFrameBuffer(rmode,xfb,COLOR_BLACK);
+
 	// Wait for Video setup to complete
 	VIDEO_WaitVSync();
 	if(rmode->viTVMode&VI_NON_INTERLACE) VIDEO_WaitVSync();

--- a/templates/makefile/application/source/template.c
+++ b/templates/makefile/application/source/template.c
@@ -38,6 +38,9 @@ int main(int argc, char **argv) {
 
 	// Flush the video register changes to the hardware
 	VIDEO_Flush();
+	
+    // Clear framebuffer
+    VIDEO_ClearFrameBuffer(rmode,xfb,COLOR_BLACK);
 
 	// Wait for Video setup to complete
 	VIDEO_WaitVSync();

--- a/threading/source/main.c
+++ b/threading/source/main.c
@@ -291,6 +291,9 @@ void Init() {
 	// Flush the video register changes to the hardware
 	VIDEO_Flush();
 
+    // Clear framebuffer
+    VIDEO_ClearFrameBuffer(rmode,xfb,COLOR_BLACK);
+
 	// Wait for Video setup to complete
 	VIDEO_WaitVSync();
 	if(rmode->viTVMode&VI_NON_INTERLACE) VIDEO_WaitVSync();


### PR DESCRIPTION
This update fixes the green border that shows up in newer versions of libogc when using the text mode console.

(This green border):
<img width="1919" height="372" alt="image" src="https://github.com/user-attachments/assets/85f8d14c-4cda-46b0-982d-eb14933b906f" />
